### PR TITLE
Update to Robolectric 4.15.1

### DIFF
--- a/RetenoSdkCore/src/test/java/com/reteno/core/base/robolectric/BaseRobolectricTest.kt
+++ b/RetenoSdkCore/src/test/java/com/reteno/core/base/robolectric/BaseRobolectricTest.kt
@@ -8,7 +8,6 @@ import com.reteno.core.RetenoConfig
 import com.reteno.core.RetenoInternalImpl
 import com.reteno.core.data.local.config.RestConfig
 import com.reteno.core.data.local.database.manager.RetenoDatabaseManager
-import com.reteno.core.data.local.database.util.*
 import com.reteno.core.data.local.file.FileManager
 import com.reteno.core.data.local.sharedpref.SharedPrefsManager
 import com.reteno.core.di.ServiceLocator
@@ -25,8 +24,15 @@ import com.reteno.core.features.recommendation.Recommendation
 import com.reteno.core.lifecycle.RetenoActivityHelper
 import com.reteno.core.lifecycle.RetenoSessionHandler
 import com.reteno.core.view.iam.IamView
-import io.mockk.*
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -39,16 +45,12 @@ import org.junit.BeforeClass
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowLooper
-import org.robolectric.shadows.ShadowPackageManager
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(
     sdk = [26],
     application = RetenoTestApp::class,
-    packageName = "com.reteno.core",
-    shadows = [ShadowLooper::class, ShadowPackageManager::class]
 )
 
 abstract class BaseRobolectricTest {

--- a/RetenoSdkCore/src/test/java/com/reteno/core/domain/controller/AppLifecycleControllerTest.kt
+++ b/RetenoSdkCore/src/test/java/com/reteno/core/domain/controller/AppLifecycleControllerTest.kt
@@ -1,9 +1,7 @@
 package com.reteno.core.domain.controller
 
 import android.content.pm.PackageInfo
-import androidx.test.core.app.ApplicationProvider
 import com.reteno.core.base.robolectric.BaseRobolectricTest
-import com.reteno.core.base.robolectric.RetenoTestApp
 import com.reteno.core.data.repository.ConfigRepository
 import com.reteno.core.domain.model.event.Event
 import com.reteno.core.domain.model.event.LifecycleTrackingOptions
@@ -67,7 +65,7 @@ class AppLifecycleControllerTest : BaseRobolectricTest() {
 
 
     @Test
-    fun given_whenContrillerInit_thenBaseHtmlShouldBeFetched() = runRetenoTest {
+    fun given_whenControllerInit_thenBaseHtmlShouldBeFetched() = runRetenoTest {
         coEvery { configRepository.notificationState } returns MutableSharedFlow()
 
         val sut = createSUT(LifecycleTrackingOptions.ALL)
@@ -326,7 +324,6 @@ class AppLifecycleControllerTest : BaseRobolectricTest() {
         val sut = createSUT(LifecycleTrackingOptions(
             appLifecycleEnabled = false
         ))
-        val app = ApplicationProvider.getApplicationContext<RetenoTestApp>()
         sut.initMetadata()
 
         verify(exactly = 0) {

--- a/RetenoSdkPush/src/test/java/com/reteno/push/RetenoNotificationServiceTest.kt
+++ b/RetenoSdkPush/src/test/java/com/reteno/push/RetenoNotificationServiceTest.kt
@@ -1,7 +1,11 @@
 package com.reteno.push
 
 import android.app.NotificationManager
-import android.content.*
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.content.pm.ResolveInfo
 import android.os.Bundle
@@ -21,8 +25,19 @@ import com.reteno.push.Constants.KEY_ES_TITLE
 import com.reteno.push.base.robolectric.BaseRobolectricTest
 import com.reteno.push.channel.RetenoNotificationChannel
 import com.reteno.push.receiver.NotificationsEnabledManager
-import io.mockk.*
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
 import junit.framework.TestCase
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -34,10 +49,9 @@ import org.junit.Test
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
-import org.robolectric.shadows.ShadowNotificationManager
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@Config(sdk = [26], shadows = [ShadowNotificationManager::class])
+@Config(sdk = [26])
 class RetenoNotificationServiceTest : BaseRobolectricTest() {
 
     // region constants ----------------------------------------------------------------------------

--- a/RetenoSdkPush/src/test/java/com/reteno/push/base/robolectric/BaseRobolectricTest.kt
+++ b/RetenoSdkPush/src/test/java/com/reteno/push/base/robolectric/BaseRobolectricTest.kt
@@ -6,7 +6,9 @@ import androidx.test.core.app.ApplicationProvider
 import com.reteno.core.Reteno
 import com.reteno.core.RetenoConfig
 import com.reteno.core.RetenoInternalImpl
-import io.mockk.*
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -17,15 +19,12 @@ import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowLooper
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(
     sdk = [26],
     application = RetenoTestApp::class,
-    packageName = "com.reteno.core",
-    shadows = [ShadowLooper::class]
 )
 abstract class BaseRobolectricTest {
 
@@ -76,7 +75,6 @@ abstract class BaseRobolectricTest {
             }
         }
     }
-
 
     fun runRetenoTest(
         lifecycleOwner: LifecycleOwner = TestLifecycleOwner(),

--- a/test_dependencies.gradle
+++ b/test_dependencies.gradle
@@ -40,12 +40,7 @@ ext.powermock = dependencyGroup {
 }
 
 ext.robolectric = dependencyGroup {
-    testImplementation('org.robolectric:robolectric:4.8.1') {
-        exclude group: 'commons-logging', module: 'commons-logging'
-        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-    }
-    testImplementation 'org.robolectric:shadows-play-services:3.3.2'
-
+    testImplementation 'org.robolectric:robolectric:4.16.1'
     testImplementation 'androidx.fragment:fragment-testing:1.5.5'
 }
 


### PR DESCRIPTION
This PR updates Robolectric to its latest version 4.15.1.

Changes:
- Remove unnecessary shadows declaration in `@Config`.
- Remove `org.robolectric:shadows-play-services` since it's not needed.
- Remove some unused imports.